### PR TITLE
background size on icons

### DIFF
--- a/src/CoordinateControl.scss
+++ b/src/CoordinateControl.scss
@@ -12,7 +12,7 @@
 		cursor: pointer;
 		display: block;
 		background-image: url('location-view-icons.png');
-		background-size: 400% 200%;
+		background-size: 104px 52px;
 		background-position: 0 0;
 	}
 

--- a/src/GeocodeControl.scss
+++ b/src/GeocodeControl.scss
@@ -15,7 +15,7 @@
 	background-image: url(location-view-icons.png);
 	background-position: -26px 0px;
 	background-repeat: no-repeat;
-	background-size: 400% 200%;
+	background-size: 104px 52px;
 }
 
 .geocode-control-input {

--- a/src/GeolocationControl.scss
+++ b/src/GeolocationControl.scss
@@ -14,5 +14,5 @@
 	background-image: url(location-view-icons.png);
 	background-position: -52px 0px;
 	background-repeat: no-repeat;
-	background-size: 400% 200%;
+	background-size: 104px 52px;
 }

--- a/src/PointControl.scss
+++ b/src/PointControl.scss
@@ -15,7 +15,7 @@ a.leaflet-point-control {
 	box-shadow:0 1px 1px rgb(0,0,0);
 	background-repeat: no-repeat;
 	background-image: url(location-view-icons.png);
-	background-size: 400% 200%;
+	background-size: 104px 52px;
 	background-position: -78px 0px;
 }
 


### PR DESCRIPTION
Use pixel based background size. This fixes browsers zooming issues with alignment of the icons.
