### PR TITLE
Zooming on iPhone causes search button to go off screen.

### DIFF
--- a/src/locationview/CoordinateControl.scss
+++ b/src/locationview/CoordinateControl.scss
@@ -2,7 +2,7 @@
 .location-coordinate-control {
 
   > .expandable > input {
-    width: 88px;
+    width: 92px;
   }
 
   > .location-control-icon {

--- a/src/locationview/_controls.scss
+++ b/src/locationview/_controls.scss
@@ -59,7 +59,6 @@
   text-shadow: 1px 1px 1px rgba(255,255,255,0.6);
 }
 
-
 .location-control > .expandable {
   display: none;
 
@@ -74,7 +73,7 @@
 
   > input {
     border-left: 1px solid #ccc;
-    font-size: 13px;
+    font-size: 16px;
     padding: 0 8px;
   }
 


### PR DESCRIPTION
Fixed #79