### PR TITLE
Hide soft-keyboard on mobile

### DIFF
--- a/src/locationview/CoordinateControl.js
+++ b/src/locationview/CoordinateControl.js
@@ -155,6 +155,8 @@ var CoordinateControl =  L.Control.extend({
 
     // fire a location change
     this.setLocation(location);
+    this._latitude.blur();
+    this._longitude.blur();
   },
 
   _getCoordinateLocation: function (latitude, longitude) {

--- a/src/locationview/GeocodeControl.js
+++ b/src/locationview/GeocodeControl.js
@@ -152,6 +152,7 @@ var GeocodeControl = L.Control.extend({
   _geocodeSuccess: function (loc) {
     this._setLoading(false);
     this.setLocation(loc);
+    this._address.blur();
   },
 
   _geocodeError: function (statusCode, statusMessage) {


### PR DESCRIPTION
When a search is done for a location, hide the keyboard so that the user can see the button to set their location. 

fixes #82 